### PR TITLE
Correção do collapsed e placeholder do MapPage.vue

### DIFF
--- a/src/components/side_bar/SideBar.vue
+++ b/src/components/side_bar/SideBar.vue
@@ -2,7 +2,7 @@
 <template>
   <aside>
     <div :class="['sidebar', { 'sidebar-open': isOpen }]">
-      <div :class="['top-area', { 'top-area-open': isOpen }]">
+      <div class="top-area">
         <LogoButton v-show="showContent" />
         <MinimizeButton @click="toggleSidebar" />
       </div>
@@ -11,8 +11,6 @@
       </div>
 
       <template v-if="isSearchDone">
-        <!-- componente botão de painel: brasil / políticas públicas -->
-
         <div v-show="showContent" class="middle-area">
           <DropDown />
         </div>
@@ -40,14 +38,21 @@ import LogoButton from './buttons/LogoButton.vue';
 import BuscaSimples from '../search_dropdown/BuscaSimples.vue';
 import DropDown from './drop_down/CategoriesDropdown.vue';
 
-// Define emits
-// const emit = defineEmits(['toggle-sidebar']);
+// Props
+const props = defineProps({
+  isOpen: {
+    type: Boolean,
+    required: true
+  }
+});
+
+// Emits
+const emit = defineEmits(['toggle-sidebar']);
 
 // Store
 const locationStore = useLocationStore();
 
 // Component state
-const isOpen = ref(true);
 const showContent = ref(true);
 
 // Computed to check if search is complete
@@ -55,17 +60,14 @@ const isSearchDone = computed(() => locationStore.cd_mun && locationStore.type);
 
 // Sidebar toggle handler with animation
 async function toggleSidebar() {
-  if (isOpen.value) {
+  if (props.isOpen) {
     showContent.value = false;
-    isOpen.value = false;
   } else {
-    isOpen.value = true;
     await new Promise(resolve => setTimeout(resolve, 200));
     showContent.value = true;
   }
-  localStorage.setItem('sidebarOpen', isOpen.value);
-};
-
+  emit('toggle-sidebar');
+}
 </script>
 
 <style scoped>
@@ -89,8 +91,6 @@ async function toggleSidebar() {
     flex-direction: column;
     align-items: flex-start;
     flex-shrink: 0;
-    /* background: var(--Gray-White, #FFF); */
-    /* height: 100%; Garante que o sidebar ocupe a tela */
   }
 
   /* Rest of the styles remain unchanged */

--- a/src/pages/MapPage.vue
+++ b/src/pages/MapPage.vue
@@ -1,5 +1,4 @@
 <!-- urbverde-ui/src/pages/MapPage.vue -->
-  <!-- urbverde-ui/src/pages/MapPage.vue -->
 <template>
   <div class="layout-container">
     <Sidebar
@@ -10,7 +9,7 @@
     <!-- Main content -->
     <main
       class="main-content"
-      :class="{ 'content-expanded': !isSidebarOpen }"
+      :class="{ 'content-collapsed': !isSidebarOpen }"
     >
       <div v-if="!locationStore.cd_mun" class="placeholder-container">
         <img src="../assets/images/setLocation.png" alt="Selecione um município" class="map-placeholder" />
@@ -56,7 +55,6 @@ import Sidebar from '../components/side_bar/SideBar.vue';
 import Navbar from '../components/navbar/Navbar.vue';
 import MapBox from '../components/map/mapGenerator.vue';
 import Legenda from '../components/map/Legenda.vue';
-
 import WidgetsSection from '@/components/widgets_section/WidgetsSection.vue';
 import UrbVerdeFooter from '@/components/homepage/UrbVerdeFooter.vue';
 
@@ -223,7 +221,7 @@ useHead({
   min-height: 100vh;
   width: 100%;
   background-color: #F8F9FACC;
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 /* Sidebar styles */
@@ -251,7 +249,7 @@ useHead({
   position: relative;
 }
 
-.main-content.content-expanded {
+.main-content.content-collapsed {
   margin-left: 72px;
   width: calc(100% - 72px);
 }

--- a/src/pages/MapPage.vue
+++ b/src/pages/MapPage.vue
@@ -12,7 +12,13 @@
       :class="{ 'content-collapsed': !isSidebarOpen }"
     >
       <div v-if="!locationStore.cd_mun" class="placeholder-container">
-        <img src="../assets/images/setLocation.png" alt="Selecione um município" class="map-placeholder" />
+        <div class="placeholder-wrapper">
+          <img src="../assets/images/setLocation.png" alt="Selecione um município" />
+          <div class="label">
+            <h5 class="heading-h5">Inicie buscando um lugar</h5>
+            <p class="body-small-regular">Experimente um município ou estado</p>
+          </div>
+        </div>
       </div>
 
       <div v-else class="content-wrapper">
@@ -216,6 +222,10 @@ useHead({
 </script>
 
 <style scoped>
+h5, p{
+  margin: 0;
+}
+
 .layout-container {
   display: flex;
   min-height: 100vh;
@@ -319,13 +329,26 @@ useHead({
   display: flex;
   justify-content: center;
   align-items: center;
-  height: calc(100vh - 60px);
+  height: 100%;
   width: 100%;
 }
 
-.map-placeholder {
-  max-width: 100%;
-  height: auto;
-  opacity: 0.45;
+.placeholder-wrapper{
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 32px;
+  align-self: stretch;
 }
+
+  .placeholder-wrapper .label{
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    align-self: stretch;
+  }
+
 </style>

--- a/src/pages/MapPage.vue
+++ b/src/pages/MapPage.vue
@@ -343,6 +343,7 @@ h5, p{
 }
 
   .placeholder-wrapper .label{
+    color: #212529;
     display: flex;
     flex-direction: column;
     justify-content: center;


### PR DESCRIPTION
**Placeholder** foi ajustado conforme o Figma:

![image](https://github.com/user-attachments/assets/0320012c-a768-4467-93ab-4f14a58afdf6)

Quando Sidebar está collapsed, o MapPage.vue ajusta da forma correta:

![image](https://github.com/user-attachments/assets/331e6fcb-c0ba-46ab-94f7-794e3557c579)
