### PR TITLE
Otimização de Zoom e Escalas do Mapa

### DIFF
--- a/src/components/map/mapGenerator.vue
+++ b/src/components/map/mapGenerator.vue
@@ -100,9 +100,9 @@ let pinnedFeatureId = null;
 let hoveredSetorId = null;
 
 // Map constants
-const MAP_ZOOM_START = 14;
-const MAP_ZOOM_FINAL = 15;
-const MAP_ANIMATION_DURATION = 4000;
+const MAP_ZOOM_START = 13;
+const MAP_ZOOM_FINAL = 14;
+const MAP_ANIMATION_DURATION = 3000;
 
 // Get current layer id, scale and year from the URL query.
 const currentLayer = computed(() => route.query.layer);

--- a/src/components/map/mapGenerator.vue
+++ b/src/components/map/mapGenerator.vue
@@ -586,7 +586,7 @@ function getPopupContent(feat, config) {
   }
   // For "escala estadual" add the municipality name (if available)
   let prefix = '';
-  if ((currentScale.value === 'estadual' || currentScale.value === 'municipal') && feat.properties.nm_mun) {
+  if (currentScale.value === 'estadual' && feat.properties.nm_mun) {
     prefix = `<span style="font-size: 1.2em; font-weight: bold;">${feat.properties.nm_mun}</span><br>`;
   }
 
@@ -953,6 +953,7 @@ function initializeMap() {
     style: 'https://api.maptiler.com/maps/streets-v2/style.json?key=lEOSxnRzpX8g8OjMcRqw',
     ...initialState,
     attributionControl: false,
+    minZoom: 3.5
   });
 
   layersStore.mapRef = map.value;
@@ -986,7 +987,10 @@ function initializeMap() {
   map.value.on('zoomend', () => {
     isHandlingScaleChange.value = false;
 
-    const newScale = getScaleFromZoom(map.value.getZoom());
+    const currentZoom = map.value.getZoom();
+    const newScale = getScaleFromZoom(currentZoom);
+    console.log(`Event zoomend - Zoom atual: ${currentZoom.toFixed(2)}, Escala antiga: ${locationStore.scale}, Nova escala: ${newScale}`);
+
     if (locationStore.scale !== newScale) {
       const currentHash = window.location.hash.slice(1); // Remove # symbol
       locationStore.setLocation({ scale: newScale });
@@ -994,7 +998,6 @@ function initializeMap() {
         query: { ...route.query, scale: newScale },
         hash: currentHash // Don't slice here
       });
-
     }
   });
   map.value.on('load', () => {
@@ -1178,10 +1181,19 @@ function handleMissingImage(e) {
  * Update the "scale" based on zoom.
  */
 function getScaleFromZoom(zoom) {
-  if (zoom >= 12) { return 'intraurbana'; }
-  else if (zoom >= 6) { return 'municipal'; }
-  else if (zoom > 3) { return 'estadual'; }
-  else { return 'nacional'; }
+  let scale;
+  if (zoom >= 10) {
+    scale = 'intraurbana';
+  }
+  else if (zoom > 5) {
+    scale = 'estadual';
+  }
+  else {
+    scale = 'nacional';
+  }
+  console.log(`Zoom atual: ${zoom.toFixed(2)} => Escala determinada: ${scale}`);
+
+  return scale;
 }
 
 /* ---------------------------------------

--- a/src/components/map/mapGenerator.vue
+++ b/src/components/map/mapGenerator.vue
@@ -987,9 +987,7 @@ function initializeMap() {
   map.value.on('zoomend', () => {
     isHandlingScaleChange.value = false;
 
-    const currentZoom = map.value.getZoom();
-    const newScale = getScaleFromZoom(currentZoom);
-    console.log(`Event zoomend - Zoom atual: ${currentZoom.toFixed(2)}, Escala antiga: ${locationStore.scale}, Nova escala: ${newScale}`);
+    const newScale = getScaleFromZoom(map.value.getZoom());
 
     if (locationStore.scale !== newScale) {
       const currentHash = window.location.hash.slice(1); // Remove # symbol
@@ -1191,7 +1189,6 @@ function getScaleFromZoom(zoom) {
   else {
     scale = 'nacional';
   }
-  console.log(`Zoom atual: ${zoom.toFixed(2)} => Escala determinada: ${scale}`);
 
   return scale;
 }

--- a/src/components/map/mapGenerator.vue
+++ b/src/components/map/mapGenerator.vue
@@ -100,9 +100,9 @@ let pinnedFeatureId = null;
 let hoveredSetorId = null;
 
 // Map constants
-const MAP_ZOOM_START = 12;
-const MAP_ZOOM_FINAL = 17;
-const MAP_ANIMATION_DURATION = 8000;
+const MAP_ZOOM_START = 14;
+const MAP_ZOOM_FINAL = 15;
+const MAP_ANIMATION_DURATION = 4000;
 
 // Get current layer id, scale and year from the URL query.
 const currentLayer = computed(() => route.query.layer);


### PR DESCRIPTION
# PR: Otimização de Zoom e Escalas do Mapa

## Alterações realizadas:

1. **Otimização de performance para carregamento de tiles**:
   - Redução do MAP_ZOOM_FINAL de 17 para 14
   - Aumento do MAP_ZOOM_START de 12 para 13
   - Redução da duração da animação de 8s para 3s

2. **Simplificação do sistema de escalas**:
   - Remoção da escala 'municipal'
   - Ajuste nas condições de zoom:
     - intraurbana: zoom >= 10
     - estadual: zoom > 5 (antes > 3)
     - nacional: zoom <= 5

3. **Restrição de zoom out excessivo**:
   - Adicionado minZoom: 3.5 na inicialização do mapa

4. **Depuração**:
   - Adicionados logs para monitorar mudanças de escala durante zoom

## Benefícios:

- Redução significativa de requisições ao MapTiler
- Experiência de usuário mais fluida com animação mais curta
- Prevenção de carregamento de tiles detalhados que seriam descartados
- Simplificação da lógica de negócios com remoção de uma escala desnecessária


## Prints:
Zoom que da ao município quando carrega
![image](https://github.com/user-attachments/assets/fd5a4685-4886-4182-af0c-13739c0b6d79)

Agora é possível visualizar o município de São Paulo por inteiro sem mudar para a escala estadual:
![image](https://github.com/user-attachments/assets/8dc4a675-8bc6-4085-a372-f1183e45a852)
