### PR TITLE
Otimização de Performance do Mapa e Redução de Requests do MapTiler

### DIFF
--- a/src/components/map/controls/BasemapSwitcher.vue
+++ b/src/components/map/controls/BasemapSwitcher.vue
@@ -34,9 +34,9 @@ function toggleSatellite() {
   isSatellite.value = !isSatellite.value;
 
   if (isSatellite.value) {
-    props.map.setStyle('https://api.maptiler.com/maps/hybrid/style.json?key=eizpVHFsrBDeO6HGwWvQ');
+    props.map.setStyle('https://api.maptiler.com/maps/hybrid/style.json?key=zuxU0KiQ4drdRZ555olV');
   } else {
-    props.map.setStyle('https://api.maptiler.com/maps/basic-v2/style.json?key=eizpVHFsrBDeO6HGwWvQ');
+    props.map.setStyle('https://api.maptiler.com/maps/basic-v2/style.json?key=zuxU0KiQ4drdRZ555olV');
   }
 
   emit('satellite-toggle', isSatellite.value);

--- a/src/components/map/controls/BasemapSwitcher.vue
+++ b/src/components/map/controls/BasemapSwitcher.vue
@@ -35,31 +35,9 @@ function toggleSatellite() {
   isSatellite.value = !isSatellite.value;
 
   if (isSatellite.value) {
-    // Adiciona camada de satélite
-    props.map.addSource('satellite', {
-      type: 'raster',
-      tiles: [
-        'https://api.maptiler.com/maps/hybrid/{z}/{x}/{y}.jpg?key=eizpVHFsrBDeO6HGwWvQ'
-      ],
-      tileSize: 256
-    });
-
-    props.map.addLayer({
-      id: 'satellite-layer',
-      type: 'raster',
-      source: 'satellite',
-      paint: {
-        'raster-opacity': 1
-      }
-    }, 'municipalities-base');
+    props.map.setStyle('https://api.maptiler.com/maps/hybrid/style.json?key=eizpVHFsrBDeO6HGwWvQ');
   } else {
-    // Remove camada de satélite
-    if (props.map.getLayer('satellite-layer')) {
-      props.map.removeLayer('satellite-layer');
-    }
-    if (props.map.getSource('satellite')) {
-      props.map.removeSource('satellite');
-    }
+    props.map.setStyle('https://api.maptiler.com/maps/basic-v2/style.json?key=eizpVHFsrBDeO6HGwWvQ');
   }
 
   emit('satellite-toggle', isSatellite.value);

--- a/src/components/map/controls/BasemapSwitcher.vue
+++ b/src/components/map/controls/BasemapSwitcher.vue
@@ -13,7 +13,6 @@
 </template>
 
 <script setup>
-import { reorderAllLayers } from '@/utils/layersOrder';
 import { ref, defineProps, defineEmits } from 'vue';
 
 const props = defineProps({
@@ -41,7 +40,6 @@ function toggleSatellite() {
   }
 
   emit('satellite-toggle', isSatellite.value);
-  reorderAllLayers(props.map);
 }
 </script>
 

--- a/src/components/map/controls/customTerrainControl.js
+++ b/src/components/map/controls/customTerrainControl.js
@@ -79,7 +79,7 @@ class CustomTerrainControl {
         // Considerar usar Maptiler API com resolução ajustável
         this._map.addSource(this.options.source, {
           type: 'raster-dem',
-          url: 'https://api.maptiler.com/tiles/terrain-rgb-v2/tiles.json?key=eizpVHFsrBDeO6HGwWvQ',
+          url: 'https://api.maptiler.com/tiles/terrain-rgb-v2/tiles.json?key=zuxU0KiQ4drdRZ555olV',
           tileSize,
           maxzoom: this.options.highPerformance ? 15 : 13 // Limitar zoom para melhor desempenho
         });

--- a/src/components/map/mapGenerator.vue
+++ b/src/components/map/mapGenerator.vue
@@ -937,9 +937,7 @@ function initializeMap() {
     maxZoom: 18,
   });
 
-  // Add debug logs for map events
   map.value.on('load', () => {
-    console.log('Map loaded, starting to monitor requests');
     mapLoaded.value = true;
     hoverPopup.value = new maplibregl.Popup({
       closeButton: false,

--- a/src/components/map/mapGenerator.vue
+++ b/src/components/map/mapGenerator.vue
@@ -15,7 +15,6 @@
       :map="map"
       :current-style="currentStyle"
       :terrain-enabled="terrainEnabled"
-      @style-change="handleStyleChange"
       @terrain-toggle="handleTerrainToggle"
       @location-found="handleLocationFound"
     />
@@ -63,16 +62,6 @@ const mapLoaded = ref(false);
 // Map style state
 const currentStyle = ref('streets');
 const terrainEnabled = ref(false);
-
-// Handler functions
-function handleStyleChange(isSatellite) {
-  console.log('Satellite toggled:', isSatellite);
-
-  // Se o satélite foi ativado, apenas reordena as camadas
-  if (isSatellite) {
-    reorderAllLayers(map.value);
-  }
-}
 
 function handleTerrainToggle(enabled) {
   terrainEnabled.value = enabled;
@@ -242,7 +231,6 @@ function setupDynamicLayer() {
       }
 
       setupRasterInteractions(config);
-      reorderAllLayers(map.value);
 
     } else {
       // Adiciona layer vetorial
@@ -342,7 +330,6 @@ function setupDynamicLayer() {
         addParksLayer();
       }
       setupVectorInteractions(config);
-      reorderAllLayers(map.value);
     }
 
     setupMasterInteractionHandler(config);
@@ -375,9 +362,6 @@ function addParksLayer() {
 
   // Filtrar pois ainda não funciona cql diretamente no tile
   map.value.setFilter('parks-layer', ['==', 'cd_mun', String(locationStore.cd_mun)]);
-
-  // Reordena Layers
-  reorderAllLayers(map.value);
 }
 
 // This function sets up a master event handler for interaction priority

--- a/src/components/map/mapGenerator.vue
+++ b/src/components/map/mapGenerator.vue
@@ -171,7 +171,7 @@ function removeDynamicLayer() {
   }
 
   // Remove layers
-  ['dynamic-layer', 'dynamic-layer-outline', 'parks-layer', 'setores-layer-hover'].forEach(id => {
+  ['dynamic-layer', 'dynamic-layer-outline', 'parks-layer', 'setores-layer'].forEach(id => {
     if (map.value.getLayer(id)) {
       map.value.removeLayer(id);
     }
@@ -272,16 +272,15 @@ function setupDynamicLayer() {
         paint: {
           'line-color': '#666666',
           'line-width': 1,
-          'line-opacity': 0.1
+          'line-opacity': 0.3
         }
       });
 
-      // Aplicar filtro em ambas as camadas de contorno
       if (shouldFilter) {
         map.value.setFilter('dynamic-layer-outline', ['==', 'cd_mun', locationStore.cd_mun]);
       }
 
-      // Adiciona camada de setores hover se estiver na escala intraurbana e se não for raster
+      // Adiciona camada de setores hover se estiver na escala intraurbana
       if (currentScale.value === 'intraurbana' && currentCode.value && config.type !== 'raster') {
         // Adiciona source dos setores
         map.value.addSource('setores-source', {
@@ -294,7 +293,6 @@ function setupDynamicLayer() {
         });
 
         // Adiciona camada de setores para hover
-        // Add fill layer for hover effects
         map.value.addLayer({
           id: 'setores-layer',
           type: 'fill',
@@ -304,12 +302,16 @@ function setupDynamicLayer() {
             'fill-color': [
               'case',
               ['boolean', ['feature-state', 'hover'], false],
-              '#7c99f4',  // blue color on hover
-              'transparent'  // transparent by default
+              '#666666',
+              'transparent'
             ],
-            'fill-opacity': 0.5
+            'fill-opacity': 0.2
           }
         });
+
+        if (shouldFilter) {
+          map.value.setFilter('setores-layer', ['==', 'cd_mun', locationStore.cd_mun]);
+        }
 
         // Setup setores interactions
         map.value.on('mousemove', 'setores-layer', (e) => {
@@ -347,6 +349,7 @@ function setupDynamicLayer() {
   } catch (error) {
     console.error('Error setting up dynamic layer:', error);
   }
+  reorderAllLayers(map.value);
 }
 
 // Helper function to add parks layer

--- a/src/components/map/mapGenerator.vue
+++ b/src/components/map/mapGenerator.vue
@@ -294,29 +294,25 @@ function setupDynamicLayer() {
         });
 
         // Adiciona camada de setores para hover
+        // Add fill layer for hover effects
         map.value.addLayer({
-          id: 'setores-layer-hover',
-          type: 'line',
+          id: 'setores-layer',
+          type: 'fill',
           source: 'setores-source',
           'source-layer': 'public.geom_setores',
           paint: {
-            'line-color': [
+            'fill-color': [
               'case',
               ['boolean', ['feature-state', 'hover'], false],
-              '#495057',  // cor cinza no hover
-              'transparent'  // transparente por padrão
+              '#7c99f4',  // blue color on hover
+              'transparent'  // transparent by default
             ],
-            'line-width': 2,
-            'line-opacity': 0.8
+            'fill-opacity': 0.5
           }
         });
 
-        if (shouldFilter) {
-          map.value.setFilter('setores-layer-hover', ['==', 'cd_mun', locationStore.cd_mun]);
-        }
-
-        // Setup interações dos setores
-        map.value.on('mousemove', 'dynamic-layer', (e) => {
+        // Setup setores interactions
+        map.value.on('mousemove', 'setores-layer', (e) => {
           if (e.features.length > 0) {
             if (hoveredSetorId) {
               map.value.setFeatureState(
@@ -332,7 +328,7 @@ function setupDynamicLayer() {
           }
         });
 
-        map.value.on('mouseleave', 'dynamic-layer', () => {
+        map.value.on('mouseleave', 'setores-layer', () => {
           if (hoveredSetorId) {
             map.value.setFeatureState(
               { source: 'setores-source', id: hoveredSetorId, sourceLayer: 'public.geom_setores' },
@@ -341,11 +337,8 @@ function setupDynamicLayer() {
             hoveredSetorId = null;
           }
         });
-
-        // Adiciona camada de parques
         addParksLayer();
       }
-
       setupVectorInteractions(config);
       reorderAllLayers(map.value);
     }

--- a/src/components/map/mapGenerator.vue
+++ b/src/components/map/mapGenerator.vue
@@ -941,7 +941,7 @@ function initializeMap() {
     ...initialState,
     attributionControl: false,
     minZoom: 3.5,
-    maxZoom: 16.5,
+    maxZoom: 18,
     transformRequest: (url, resourceType) => {
       console.log('TransformRequest called:', { url, resourceType });
 

--- a/src/components/map/mapGenerator.vue
+++ b/src/components/map/mapGenerator.vue
@@ -928,43 +928,13 @@ function initializeMap() {
     }
   }
 
-  // Initialize MapTiler stats
-  window.mapTilerStats = {
-    tiles: 0,
-    renderedMaps: 0,
-    lastLogTime: Date.now()
-  };
-
   map.value = new maplibregl.Map({
     container: mapContainer.value,
-    style: 'https://api.maptiler.com/maps/basic-v2/style.json?key=eizpVHFsrBDeO6HGwWvQ',
+    style: 'https://api.maptiler.com/maps/basic-v2/style.json?key=zuxU0KiQ4drdRZ555olV',
     ...initialState,
     attributionControl: false,
     minZoom: 3.5,
     maxZoom: 18,
-    transformRequest: (url, resourceType) => {
-      console.log('TransformRequest called:', { url, resourceType });
-
-      const isMapTiler = url.includes('maptiler.com');
-      if (isMapTiler) {
-        console.log(`[MapTiler Request] Type: ${resourceType}, URL: ${url}`);
-
-        if (resourceType === 'Tile') {window.mapTilerStats.tiles++;}
-        if (resourceType === 'RenderedMap') {window.mapTilerStats.renderedMaps++;}
-
-        const now = Date.now();
-        if (now - window.mapTilerStats.lastLogTime > 5000) {
-          console.log('[MapTiler Stats]', {
-            tiles: window.mapTilerStats.tiles,
-            renderedMaps: window.mapTilerStats.renderedMaps,
-            timeElapsed: `${(now - window.mapTilerStats.lastLogTime) / 1000  }s`
-          });
-          window.mapTilerStats.lastLogTime = now;
-        }
-      }
-
-      return { url };
-    }
   });
 
   // Add debug logs for map events

--- a/src/utils/layersOrder.js
+++ b/src/utils/layersOrder.js
@@ -8,7 +8,7 @@ const LAYER_ORDER = [
   'municipalities-base-outline', // Camada de contorno de municípios
   'parks-layer', // Camada de parques nacionais
   'dynamic-layer-outline', // Camada de setor censitário de contorno
-  'setores-layer-hover', // Camada de setor censitário de contorno de hover
+  'setores-layer', // Camada de setor censitário de contorno de hover
   'dynamic-layer', // Camada selecionada
   'satellite-layer', // Camada de satélite
 ];


### PR DESCRIPTION
# Contexto:

- Ultimamente a gente se deparou com **grandes quantidades de requests no Maptiler**, biblioteca que usamos que aparece o mapa base e que fazemos toda o CRUD de camadas. Por conta disso, atingia o limite estabelecido da key (100k/mês de request, ou 500k/mês para o caso de ser uma key com plano pro).
- Estamos com grande **quantidade de acessos ultimamente**, que com certeza há um aumento das requests no MapTiler. Mas, mesmo assim, a **média de requests por dia estava alta**, sendo necessário dar uma estudada maior nisso e buscar resoluções.
- Além disso, nas últimas atualizações, **realizei modificações no mapgenerator que pode ter influenciado, e busquei todas essas modificações e analisei com mais cuidado agora cada uma**, até voltei algumas da forma que era realizado anteriormente, como o hover, que vou explicar mais para o fim do texto.

# Análises prévias:
**Adicionei diversos logs** para identificar quando há a chamada na requests, identifiquei pontos problemáticos:

- Abertura do /mapa com camada padrão (Temperatura de Superfície): 120 requests
- Troca de camada (camada A → camada B): 25–30 TransformRequest
- Zoom out no município (nível municipal): 250
- Zoom in no município: 200 (quanto mais zoom, mais requests utilizava)
- Passagem de um município para outro (mudança de centro): 500 TransformRequest

(Analisei diversos outros, mas esses foram os mais "interessantes")

# Modificações:
## 1. Mapa de base: 
Acredito que um dos principais pontos de impacto!

Estava sendo utilizado o mapa de base "Streets-v2", que é nativo, mas muito mais pesado, com muitas informações e isso tornava a quantidade de requests muito mais alta. Veja uma comparação:

#### **Streets-v2** - Usado há 3 semanas

![image](https://github.com/user-attachments/assets/748f1c06-238d-43f6-b6f9-059cfb122958)

- Mais pesado e lento
- Zoom mais próximo possui MUITOS detalhes e edificios em 3d, muita request
- Alto número de requests
- Grande quantidade de detalhes e POIs
- Qualidade visual superior
- Maior impacto na performance

#### **Personalizado** - Usado desde o começo até há 3 semanas atrás

![image](https://github.com/user-attachments/assets/5d6e03c8-cb7c-4cf2-ba01-a6150aa7bb92)

- Número de requests intermediário
- Zoom mais próximo possui MUITOS detalhes e edificios em 3d, muita request
- Tinha falhas de renderização por não ser nativo, como “falhas na cor preta” que aparecia no mapa ao dar zooms e pans no mapa
- Menos otimizado que os mapas nativos
- Visual mais limpo
- Detalhes balanceados

#### **Basic-v2** - O que estou pensando em usar agora

![image](https://github.com/user-attachments/assets/e4f22ec6-4153-4baa-9097-9aa48a5bfda1)

- Mais leve e rápido
- Zoom mais próximo possui poucos detalhes, mas apenas o necessário para visualização. Sem edifícios em 3d
- Menor número de requests
- Otimizado nativamente
- Poucos bugs de renderização
- Menos detalhes e POIs
-  Além disso, quando há o **ativamento do modo 3d**, nos outros há uma alta requisição de requests por conta de ter que retirar os edificios em 3d e modificar toda a estrutura do mapa. Algo que no basic-v2 não acontece, se tornando mais otimizado e com menos requests.

Portanto, apesar de o **personalizado** ser mais "clean" e o **streets-v2** ter uma maior quantidade de dados que pode ajudar na localização do usuário, o **basic-v2** é o **mais leve, mais otimizado**, acredito que **reduz consideravelmente o número de requests, e esse é um dos principais pontos de impacto**, além de contém as informações necessárias para a análise do mapa. Decidi usá-lo, mas estou aberto à discussões :)

## 2. Zoom do mapa ao abrir o município:

```
const MAP_ZOOM_START = 14;
const MAP_ZOOM_FINAL = 14;
const MAP_ANIMATION_DURATION = 1000;
```

Ao adicionar isso, não dá mais o "zoom" ao abrir o mapa, que reduz **em, no mínimo, 50** o número de requests

## 3. Substituição de flyTo por jumpTo
Acredito que um dos principais pontos de impacto!

Foi substituida a função flyTo, utilizando a jumpTo, agora ao mudar de município, não "voa" para ele, apenas aparece o município

![gif](https://github.com/user-attachments/assets/1f5337a3-2318-4a1c-b7cf-1eb187e96a95)

Impacto: **Redução de no mínimo 300 requests**, além de uma resposta mais rápida e no momento para o usuário

## 4. Otimização do BasemapSwitcher
Acredito que um dos principais pontos de impacto!

- Substituição de `map.addLayer` por `setStyle` para troca de mapas
- Isso **reduz consideravelmente as requests** e é a forma correta de mudar o basemap, já que não mais "adiciona" em cima, e sim substitui o `basic-v2 `pelo mapa `hybrid `(o de satelite)

**Problema**: Só que a camada não aparece por cima, pois esse setstyle “reseta” o mapa. então precisa clicar na camada novamente para aparecer, por enquanto (acho um problema ok). O certo seria chamar novamente a função para adicionar a camada no mapa, mas precisa dar uma refatorada nessa função do mapgenerator para isso dar certo.

## 5. Simplificação do Sistema de Hover
Acredito que um dos principais pontos de impacto!

- Retorno ao sistema anterior com polígonos mais simples
- Implementação de filtro para redução de requests
- **Impacto**: **0 requests durante interações de hover**

## 6. LayersOrder
- Remoção de chamadas redundantes de bringmapbasetofront (que antigamente era chamado diversas vezes), e sua substituição pelo `LayersOrder`, **que é chamado uma única vez e abstrai toda lógica de sequencia das camadas**.

## 7. Filtragem nas camadas
- Todas as **camadas agora são filtradas pelo município do usuário**, isso reduz a quantidade de requests de renderização do mapa, principalmente quando da zoom out, já que aparece apenas os dados necessários.

# Testes Realizados
- Verificação de performance em diferentes níveis de zoom
- Testes de interação com hover
- Validação de transições entre municípios
- Monitoramento de requests em diferentes cenários de uso

# Próximos Passos
- Monitoramento contínuo de métricas de performance, para analisar a efetividade da otimização. 
- A partir de uma pesquisa em documentações, acredito que o `basic-v2` possui menos requests que o `personalizado`, mas ainda é algo que quero verificar melhor