### PR TITLE
Correção do bug de transição entre paineis no mobile

### DIFF
--- a/src/pages/MapPage.vue
+++ b/src/pages/MapPage.vue
@@ -29,8 +29,7 @@
         </div>
       </div>
 
-      <div v-else class="content-wrapper content-animate">
-
+      <div v-else class="content-wrapper content-animate" :class="{ 'fade-transition': isViewModeTransitioning }">
         <Navbar
           ref="navbarRef"
           :class="{ 'navbar-collapsed': !isSidebarOpen }"
@@ -107,9 +106,23 @@ const route = useRoute();
 const activeSection = ref('map');
 const isSidebarOpen = ref(true);
 const showBackToTop = ref(false);
+const isViewModeTransitioning = ref(false);
 const hasMunicipality = computed(() => !!locationStore.cd_mun);
 const defaultYear = computed(() => locationStore.year);
 const cityCode = ref(3547809);
+
+// Watcher para controlar a animação de fade quando viewMode muda
+watch(() => locationStore.viewMode, (newMode, oldMode) => {
+  if (newMode !== oldMode) {
+    // Iniciar transição
+    isViewModeTransitioning.value = true;
+
+    // Resetar após a animação completa
+    setTimeout(() => {
+      isViewModeTransitioning.value = false;
+    }, 500);
+  }
+});
 
 // Função para verificar se deve ocultar o mapa baseado no ID da categoria ou camada
 const shouldHideMap = computed(() => {
@@ -570,6 +583,17 @@ h5, p{
     to {
       opacity: 1;
     }
+  }
+
+  /* Animação simples de fade quando viewMode muda */
+  .content-wrapper {
+    opacity: 1;
+    transition: opacity 0.3s ease-in-out;
+  }
+
+  .content-wrapper.fade-transition {
+    opacity: 0;
+    transition: opacity 0.0s ease-in-out;
   }
 
   @include breakpoint-down('tablet') {

--- a/src/pages/MapPage.vue
+++ b/src/pages/MapPage.vue
@@ -29,7 +29,7 @@
         </div>
       </div>
 
-      <div v-else :key="locationStore.viewMode" class="content-wrapper content-animate">
+      <div v-else class="content-wrapper content-animate">
 
         <Navbar
           ref="navbarRef"
@@ -287,9 +287,6 @@ watch([
     isSidebarOpen.value = true;
   }
 }, { immediate: true });
-
-// Watch para viewMode para garantir que a animação seja executada
-watch(() => locationStore.viewMode, () => {});
 
 const navbarRef = ref(null);
 const navbarHeight = ref(0);


### PR DESCRIPTION
Pelo uso de :key para a animação, que "reconstroi" o componente todo, estava bugando a transição no mobile. Por isso, foi feito outra animação usando :class e CSS puro.